### PR TITLE
AxiomaticTerms are no longer obliterated

### DIFF
--- a/python/parser/fs_task.py
+++ b/python/parser/fs_task.py
@@ -150,11 +150,6 @@ class FSTaskIndex(object):
         # All symbols appearing on some action effect are fluent
         self.fluent_symbols = set(pddl_helper.get_effect_symbol(eff) for action in actions for eff in action.effects)
 
-        # MRJ: very unsatisfying fix
-        for sym in self.all_symbols :
-            if util.is_external(sym) : # symbol is procedurally defined
-                self.fluent_symbols.add( sym )
-
         # The rest are static, including, by definition, the equality predicate
         self.static_symbols = set(s for s in self.all_symbols if s not in self.fluent_symbols) | set("=")
 

--- a/python/parser/parser.py
+++ b/python/parser/parser.py
@@ -34,6 +34,8 @@ class Parser(object):
             result = fs.Tautology()
         elif isinstance(exp, str):
             result = fs.LogicalVariable(exp) if exp[0] == '?' else fs.Constant(exp)
+        elif isinstance(exp,int):
+            result = fs.Constant(exp)
         else:
             raise exceptions.ParseException("Unknown expression type for expression '{}'".format(exp))
 

--- a/python/parser/representation.py
+++ b/python/parser/representation.py
@@ -102,8 +102,8 @@ class ProblemRepresentation(object):
             static = name in self.index.static_symbols
 
             # Store the symbol info as a tuple:
-            # <symbol_id, symbol_name, symbol_type, <function_domain>, function_codomain, state_variables, static?>
-            res.append([i, name, type_, symbol.arguments, symbol.codomain, f_variables, static])
+            # <symbol_id, symbol_name, symbol_type, <function_domain>, function_codomain, state_variables, static?, unbounded_arity?>
+            res.append([i, name, type_, symbol.arguments, symbol.codomain, f_variables, static, util.has_unbounded_arity(name)])
         return res
 
     def dump_type_data(self):
@@ -160,7 +160,7 @@ class ProblemRepresentation(object):
         return len([s for s in self.index.all_symbols if util.is_external(s)])
 
     def get_function_instantiations(self):
-        return [tplManager.get('function_instantiation').substitute(name=symbol, accessor=symbol[1:])
+        return [tplManager.get('function_instantiation').substitute(name=symbol, accessor=symbol.replace('@',''))
                 for symbol in self.index.static_symbols if util.is_external(symbol)]
 
     def print_debug_data(self, data):

--- a/python/parser/runner.py
+++ b/python/parser/runner.py
@@ -89,7 +89,11 @@ def move_files(base_dir, instance, domain, target_dir, use_vanilla):
         for filename in glob.glob(os.path.join(origin_data_dir, '*')):
             if os.path.isfile(filename):
                 shutil.copy(filename, data_dir)
-
+            else :
+                dst = os.path.join(data_dir,os.path.basename(filename))
+                if os.path.exists( dst ) :
+                    shutil.rmtree(dst)
+                shutil.copytree(filename, dst)
 
 def compile_translation(translation_dir, use_vanilla, args):
     """

--- a/python/parser/util.py
+++ b/python/parser/util.py
@@ -49,6 +49,9 @@ def bool_string(value):
 def is_external(symbol):
     return symbol[0] == '@'
 
+def has_unbounded_arity(symbol) :
+    return symbol[0:2] == '@@'
+
 
 class UninitializedAttribute(object):
     def __init__(self, name):

--- a/src/problem_info.cxx
+++ b/src/problem_info.cxx
@@ -15,29 +15,29 @@ std::unique_ptr<ProblemInfo> ProblemInfo::_instance = nullptr;
 ProblemInfo::ProblemInfo(const rapidjson::Document& data, const std::string& data_dir) :
 	_data_dir(data_dir)
 {
-	
+
 	LPT_INFO("main", "Loading Type index...");
 	loadTypeIndex(data["types"]); // Order matters
-	
+
 	LPT_INFO("main", "Loading Object index...");
 	loadObjectIndex(data["objects"]);
 
 	LPT_INFO("main", "Loading Symbol index...");
 	loadSymbolIndex(data["symbols"]);
-	
+
 	LPT_INFO("main", "Loading Variable index...");
 	loadVariableIndex(data["variables"]);
-	
+
 	LPT_INFO("main", "Loading Metadata...");
 	loadProblemMetadata(data["problem"]);
-	
+
 	LPT_INFO("main", "All indexes loaded");
-	
+
 	// Load the cached map of predicative variables for more performant access
 	for (unsigned variable = 0; variable < getNumVariables(); ++variable) {
 		_predicative_variables.push_back(isPredicate(getVariableData(variable).first));
 	}
-	
+
 	_extensions.resize(getNumLogicalSymbols());
 }
 
@@ -70,23 +70,23 @@ unsigned ProblemInfo::getNumObjects() const { return objectNames.size(); }
 
 void ProblemInfo::loadVariableIndex(const rapidjson::Value& data) {
 	assert(variableNames.empty());
-	
+
 	for (unsigned i = 0; i < data.Size(); ++i) {
 		unsigned id = variableNames.size();
 		assert(data[i]["id"].GetInt() >= 0 && static_cast<unsigned>(data[i]["id"].GetInt()) == id); // Check values are decoded in the proper order
-		
+
 		const std::string type(data[i]["type"].GetString());
 		const std::string name(data[i]["name"].GetString());
 		variableNames.push_back(name);
 		variableIds.insert(std::make_pair(name, id));
-		
+
 		variableGenericTypes.push_back(getGenericType(type));
 		try {
 			variableTypes.push_back(name_to_type.at(type));
 		} catch( std::out_of_range& ex ) {
 			throw std::runtime_error("Unknown type " + type);
 		}
-		
+
 		// Load the info necessary to resolve state variables dynamically
 		const auto& var_data = data[i]["data"];
 		unsigned symbol_id = var_data[0].GetInt();
@@ -94,7 +94,7 @@ void ProblemInfo::loadVariableIndex(const rapidjson::Value& data) {
 		for (unsigned j = 0; j < var_data[1].Size(); ++j) {
 			constants.push_back(var_data[1][j].GetInt());
 		}
-		
+
 		variableDataToId.insert(std::make_pair(std::make_pair(symbol_id, constants),  id));
 		variableIdToData.push_back(std::make_pair(symbol_id, constants));
 	}
@@ -102,7 +102,7 @@ void ProblemInfo::loadVariableIndex(const rapidjson::Value& data) {
 
 void ProblemInfo::loadSymbolIndex(const rapidjson::Value& data) {
 	assert(symbolIds.empty());
-	
+
 
 	// Symbol data is stored as: # <symbol_id, symbol_name, symbol_type, <function_domain>, function_codomain, state_variables, static?>
 	for (unsigned i = 0; i < data.Size(); ++i) {
@@ -116,26 +116,27 @@ void ProblemInfo::loadSymbolIndex(const rapidjson::Value& data) {
 		const std::string symbol_type = data[i][2].GetString();
 		assert (symbol_type == "function" || symbol_type == "predicate");
 		const SymbolData::Type type = (symbol_type == "function") ? SymbolData::Type::FUNCTION : SymbolData::Type::PREDICATE;
-		
+
 		// Parse the domain IDs
 		const auto& domains = data[i][3];
 		Signature domain;
 		for (unsigned j = 0; j < domains.Size(); ++j) {
 			domain.push_back(getTypeId(domains[j].GetString()));
 		}
-		
+
 		// Parse the codomain ID
 		TypeIdx codomain = getTypeId(data[i][4].GetString());
-		
+
 		// Parse the function variables
 		std::vector<VariableIdx> variables;
 		const auto& list = data[i][5];
 		for (unsigned j = 0; j < list.Size(); ++j) {
 			variables.push_back(list[j][0].GetInt());
 		}
-		
+
 		bool is_static = data[i][6].GetBool();
-		_functionData.push_back(SymbolData(type, domain, codomain, variables, is_static));
+        bool has_unbounded_arity = data[i][7].GetBool();
+		_functionData.push_back(SymbolData(type, domain, codomain, variables, is_static, has_unbounded_arity));
 	}
 }
 
@@ -154,7 +155,7 @@ ProblemInfo::ObjectType ProblemInfo::getGenericType(const std::string& type) con
 //! Load the names of the problem objects from the specified file.
 void ProblemInfo::loadObjectIndex(const rapidjson::Value& data) {
 	assert(objectNames.empty());
-	
+
 	for (unsigned i = 0; i < data.Size(); ++i) {
 		assert(data[i]["id"].GetInt() >= 0 && static_cast<unsigned>(data[i]["id"].GetInt()) == objectNames.size()); // Check values are decoded in the proper order
 		const std::string& name = data[i]["name"].GetString();
@@ -167,29 +168,29 @@ void ProblemInfo::loadObjectIndex(const rapidjson::Value& data) {
 void ProblemInfo::loadTypeIndex(const rapidjson::Value& data) {
 	assert(type_to_name.empty());
 	unsigned num_types = data.Size();
-	
+
 	typeObjects.resize(num_types); // Resize the vector to the number of types that we have
 	isTypeBounded.resize(num_types);
 	typeBounds.resize(num_types);
-	
+
 	for (unsigned i = 0; i < data.Size(); ++i) {
 		TypeIdx type_id = data[i][0].GetInt();
 		std::string type_name(data[i][1].GetString());
 		assert(type_id == type_to_name.size()); // Check values are decoded in the proper order
-		
+
 		name_to_type.insert(std::make_pair(type_name, type_id));
 		type_to_name.push_back(type_name);
-		
+
 		// We read and convert to integer type the vector of Object indexes
 		if (data[i][2].IsString()) {
 			assert(std::string(data[i][2].GetString()) == "int" && data[i].Size() == 4);
 			int lower = data[i][3][0].GetInt();
 			int upper = data[i][3][1].GetInt();
 			if (lower > upper) throw std::runtime_error("Incorrect bounded integer expression: [" + std::to_string(lower) + ", " + std::to_string(upper) + "]");
-			
+
 			typeBounds[type_id] = std::make_pair(lower, upper);
 			isTypeBounded[type_id] = true;
-			
+
 			// Unfold the range
 			typeObjects[type_id].reserve(upper - lower + 1);
 			for (int v = lower; v <= upper; ++v) typeObjects[type_id].push_back(v);

--- a/src/problem_info.hxx
+++ b/src/problem_info.hxx
@@ -15,31 +15,33 @@ class Atom;
 //! Data related to function and predicate symbols
 class SymbolData {
 public:
-	
+
 	enum class Type {PREDICATE, FUNCTION};
-	
-	SymbolData(Type type, const Signature& signature, TypeIdx codomain, std::vector<VariableIdx>& variables, bool stat):
-		_type(type), _signature(signature), _codomain(codomain), _variables(variables), _static(stat) {}
-	
+
+	SymbolData(Type type, const Signature& signature, TypeIdx codomain, std::vector<VariableIdx>& variables, bool stat, bool unbounded):
+		_type(type), _signature(signature), _codomain(codomain), _variables(variables), _static(stat), _unbounded_arity(unbounded) {}
+
 	//! Returns the state variables derived from the given function (e.g. for a function "f", f(1), f(2), ...)
 	const std::vector<VariableIdx>& getStateVariables() const {
 		assert(!_static);
 		return _variables;
 	}
-	
+
 	Type getType() const { return _type; }
 	const Signature& getSignature() const { return _signature; }
 	const TypeIdx& getCodomainType() const { return _codomain; }
 	unsigned getArity() const { return _signature.size(); }
-	
+
 	bool isStatic() const { return _static; }
-	
+
+    bool hasUnboundedArity() const { return _unbounded_arity; }
+
 	//! Sets/Gets the actual implementation of the function
 	void setFunction(const Function& function) {
 		assert(_static);
 		_function = function;
 	}
-	const Function& getFunction() const { 
+	const Function& getFunction() const {
 		assert(_function);
 		return _function;
 	}
@@ -50,7 +52,8 @@ protected:
 	TypeIdx _codomain;
 	std::vector<VariableIdx> _variables;
 	bool _static;
-	
+    bool _unbounded_arity;
+
 	//! The actual implementation of the function
 	Function _function;
 };
@@ -61,91 +64,91 @@ protected:
 class ProblemInfo {
 public:
 	enum class ObjectType {INT, BOOL, OBJECT};
-	
+
 	//! Set the global singleton problem instance
 	static ProblemInfo& setInstance(std::unique_ptr<ProblemInfo>&& problem) {
 		assert(!_instance);
 		_instance = std::move(problem);
 		return *_instance;
 	}
-	
+
 	//! Global singleton object accessor
 	static const ProblemInfo& getInstance() {
 		assert(_instance);
 		return *_instance;
 	}
-	
+
 protected:
 	//! The singleton instance
 	static std::unique_ptr<ProblemInfo> _instance;
-	
+
 	//! A map from state variable ID to state variable name
 	std::vector<std::string> variableNames;
-	
+
 	//! A map from state variable name to state variable ID
 	std::map<std::string, VariableIdx> variableIds;
-	
+
 	//! A map from the actual data "f(t1, t2, ..., tn)" to the assigned variable ID
 	std::map<std::pair<unsigned, std::vector<ObjectIdx>>, VariableIdx> variableDataToId;
 	std::vector<std::pair<unsigned, std::vector<ObjectIdx>>> variableIdToData;
-	
+
 	//! A map from state variable index to the type of the state variable
 	std::vector<ObjectType> variableGenericTypes;
-	
+
 	//! Maps variable index to type index
 	std::vector<TypeIdx> variableTypes;
-	
+
 	//! A map from object index to object name
 	std::vector<std::string> objectNames;
-	
+
 	//! A map from object name to object index
 	std::map<std::string, ObjectIdx> objectIds;
-	
+
 	//! A map from type ID to all of the object indexes of that type
 	std::vector<ObjectIdxVector> typeObjects;
-	
+
 	//! An integer type will have associated lower and upper bounds.
 	std::vector<std::pair<int, int>> typeBounds;
 	std::vector<bool> isTypeBounded;
-	
+
 	//! Maps between typenames and type IDs.
 	std::unordered_map<std::string, TypeIdx> name_to_type;
 	std::vector<std::string> type_to_name;
-	
+
 	//! Maps between predicate and function symbols names and IDs.
 	std::vector<std::string> symbolNames;
 	std::map<std::string, SymbolIdx> symbolIds;
-	
+
 	//! A map from function ID to the function data
 	std::vector<SymbolData> _functionData;
-	
+
 	//! The names of the problem domain and instance
 	std::string _domain;
 	std::string _instance_name;
-	
+
 	//! The extensions of the static symbols
 	std::vector<std::unique_ptr<StaticExtension>> _extensions;
-	
+
 	std::unique_ptr<ExternalI> _external;
-	
+
 public:
 	ProblemInfo(const rapidjson::Document& data, const std::string& data_dir);
 	~ProblemInfo() = default;
-	
+
 	const std::string& getVariableName(VariableIdx index) const;
 	inline VariableIdx getVariableId(const std::string& name) const { return variableIds.at(name); }
-	
-	
+
+
 	const TypeIdx getVariableType(VariableIdx index) const { return variableTypes.at(index); }
 	const ObjectType getVariableGenericType(VariableIdx index) const { return variableGenericTypes.at(index); }
-	
+
 	unsigned getNumVariables() const;
-	
+
 	const std::string getObjectName(VariableIdx varIdx, ObjectIdx objIdx) const;
 	const std::string deduceObjectName(ObjectIdx object, TypeIdx type) const;
-	const std::string deduceObjectName(ObjectIdx object, const std::string& type) const { return deduceObjectName(object, getTypeId(type)); }      
+	const std::string deduceObjectName(ObjectIdx object, const std::string& type) const { return deduceObjectName(object, getTypeId(type)); }
 	inline ObjectIdx getObjectId(const std::string& name) const { return objectIds.at(name); }
-	
+
 	//! Return the ID of the function with given name
 	inline SymbolIdx getSymbolId(const std::string& name) const { return symbolIds.at(name); }
 	const std::string& getSymbolName(unsigned symbol_id) const { return symbolNames.at(symbol_id); }
@@ -153,25 +156,25 @@ public:
 	unsigned getNumLogicalSymbols() const { return symbolIds.size(); }
 	bool isPredicate(unsigned symbol_id) const { return getSymbolData(symbol_id).getType() == SymbolData::Type::PREDICATE; }
 	bool isFunction(unsigned symbol_id) const { return getSymbolData(symbol_id).getType() == SymbolData::Type::FUNCTION; }
-	
+
 	bool isPredicativeVariable(VariableIdx variable) const { return _predicative_variables.at(variable); }
 	bool isNegatedPredicativeAtom(const Atom& atom) const;
-	
+
 	void setFunction(unsigned functionId, const Function& function) {
 		_functionData.at(functionId).setFunction(function);
 	}
 	inline const SymbolData& getSymbolData(unsigned functionId) const { return _functionData.at(functionId); }
-	
-	
+
+
 	void set_extension(unsigned symbol_id, std::unique_ptr<StaticExtension>&& extension);
 	const StaticExtension& get_extension(unsigned symbol_id) const;
-	
+
 	void set_external(std::unique_ptr<ExternalI> external) { _external = std::move(external); }
 	const ExternalI& get_external() const {
 		assert(_external);
 		return *_external;
 	}
-	
+
 	//! A convenient helper
 	template <typename ExtensionT>
 	const ExtensionT& get_extension(const std::string& symbol) const {
@@ -181,17 +184,17 @@ public:
 		assert(extension);
 		return *extension;
 	}
-	
+
 	//! Returns all the objects of the given type _or of a descendant type_
 	inline const std::vector<ObjectIdxVector>& getTypeObjects() const { return typeObjects; }
 	inline const ObjectIdxVector& getTypeObjects(TypeIdx type) const { return typeObjects.at(type); }
 	inline const ObjectIdxVector& getTypeObjects(const std::string& type_name) const { return typeObjects.at(getTypeId(type_name)); }
 
 	//! Returns all the objects of the type of the given variable
-	inline const ObjectIdxVector& getVariableObjects(const VariableIdx variable) const { 
+	inline const ObjectIdxVector& getVariableObjects(const VariableIdx variable) const {
 		return getTypeObjects(getVariableType(variable));
 	}
-	
+
 	inline TypeIdx getTypeId(const std::string& type_name) const {
 		auto it = name_to_type.find(type_name);
 		if (it == name_to_type.end()) {
@@ -199,68 +202,68 @@ public:
 		}
 		return it->second;
 	}
-	
+
 	inline const std::string& getTypename(TypeIdx type) const { return type_to_name.at(type); }
-	
-	
+
+
 	//! Resolves a pair of function ID + an assignment of values to their parameters to the corresponding state variable.
 	VariableIdx resolveStateVariable(unsigned symbol_id, std::vector<ObjectIdx>&& constants) const { return variableDataToId.at(std::make_pair(symbol_id, std::move(constants))); }
 	VariableIdx resolveStateVariable(unsigned symbol_id, const std::vector<ObjectIdx>& constants) const { return variableDataToId.at(std::make_pair(symbol_id, constants)); }
-	
+
 	//! Return the data that originated a state variable
 	const std::pair<unsigned, std::vector<ObjectIdx>>& getVariableData(VariableIdx variable) const { return variableIdToData.at(variable); }
-	
-	
-	
+
+
+
 	//! Resolves a function ID to all state variables in which the function can result
 	const VariableIdxVector& resolveStateVariable(unsigned symbol_id) const { return getSymbolData(symbol_id).getStateVariables(); }
-	
-	
+
+
 	const std::string& getCustomObjectName(ObjectIdx objIdx) const;
-	
+
 	unsigned getNumObjects() const;
-	
+
 	//! Both methods check that the value of a given variable is within the bounds of the variable,
 	//! in case it is a variable of a bounded type.
 	bool checkValueIsValid(const Atom& atom) const;
 	bool checkValueIsValid(VariableIdx variable, ObjectIdx value) const;
-	
+
 	bool isBoundedType(TypeIdx type) const { return isTypeBounded[type];  }
 	bool isBoundedVariable(VariableIdx variable) const { return isBoundedType(getVariableType(variable));  }
-	
+
 	const std::pair<int,int>& getTypeBounds(TypeIdx type) const {
 		assert(isBoundedType(type));
 		return typeBounds.at(type);
 	}
-	
+
 	void setDomainName(const std::string& domain) { _domain = domain; }
 	void setInstanceName(const std::string& instance) { _instance_name = instance; }
 	const std::string& getDomainName() const { return _domain; }
 	const std::string& getInstanceName() const { return _instance_name; }
-	
+
 	//! Returns the generic type (object, int, bool, etc.) corresponding to a concrete type
 	ObjectType getGenericType(TypeIdx typeId) const;
 	ObjectType getGenericType(const std::string& type) const;
-	
-	const std::string& getDataDir() const { return _data_dir; } 
-	
+
+	const std::string& getDataDir() const { return _data_dir; }
+
 protected:
-	//! Load all the function-related data 
+	//! Load all the function-related data
 	void loadSymbolIndex(const rapidjson::Value& data);
-	
+
 	//! Load the names of the state variables
 	void loadVariableIndex(const rapidjson::Value& data);
-	
+
 	//! Load the names of the problem objects
 	void loadObjectIndex(const rapidjson::Value& data);
-	
+
 	//! Load all type-related info.
 	void loadTypeIndex(const rapidjson::Value& data);
-	
+
 	void loadProblemMetadata(const rapidjson::Value& data);
-	
+
 	std::vector<bool> _predicative_variables;
-	
+
 	//! The filesystem directory where the problem serialized data is found
 	const std::string _data_dir;
 };


### PR DESCRIPTION
AxiomaticTerms were being obliterated... due to a variety of reasons. We need to test the rest of the domains with procedural terms on action effects and preconditions to determine if this works correctly or not.

Major changes:

 - Cherry-picked several improvements on the front-end from the ```hybrid-planning-support``` branch
 - Binding operation now dispatches correctly AxiomaticTerms (at least on one case, see changes to ```src/languages/fstrips/operations/binding.cxx``` below.
 - Support for unbounded arity terms, denoted by the prefix @@ has been added.